### PR TITLE
[김법균] 포스트페이지 프로필 공유 기능 추가

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="ko">
+
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -8,9 +9,14 @@
 </head>
 
 <body>
-
+  <script src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.1/kakao.min.js"
+    integrity="sha384-kDljxUXHaJ9xAb2AzRd59KxjrFjzHa5TAoFQ6GbYTCAG0bjM55XohjjDT7tDDC01"
+    crossorigin="anonymous"></script>
+  <script>
+    Kakao.init('2bc24641675f91dae9be60e52cab838e');
+    console.log(Kakao.isInitialized());
+  </script>
   <div id="root"></div>
-
 </body>
 
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import "./assets/styles/global.css";
 import "./assets/styles/reset.css";
 import Main from "./pages/main/Main";
 import QuestionCardListPage from "./pages/QuestionCardListPage";
+import PostPage from "./pages/PostPage/PostPage";
 
 function App() {
   return (
@@ -11,6 +12,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Main />} />
         <Route path="/list" element={<QuestionCardListPage />} />
+        <Route path="/post" element={<PostPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/PostProfile/PostProfile.jsx
+++ b/src/components/PostProfile/PostProfile.jsx
@@ -3,6 +3,8 @@ import styles from "./PostProfile.module.css";
 import faceBookImage from "../../assets/images/shareicon/Facebook.svg";
 import kakaoImage from "../../assets/images/shareicon/Kakao.svg";
 import linkShareImage from "../../assets/images/shareicon/Link.svg";
+import { shareKakao } from "../../utils/shareKakao";
+import { useEffect } from "react";
 
 const POST_BASE_URL = "https://openmind-api.vercel.app/5-4/post";
 
@@ -27,8 +29,16 @@ export default function PostProfile({ userProfile }) {
       onClick: handleCopyLinkClipBoard,
     },
     { altMessage: "link to facebook", imgSource: faceBookImage },
-    { altMessage: "link to kakao", imgSource: kakaoImage },
+    { altMessage: "link to kakao", imgSource: kakaoImage, onClick: shareKakao },
   ];
+
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://developers.kakao.com/sdk/js/kakao.js";
+    script.async = true;
+    document.body.appendChild(script);
+    return () => document.body.removeChild(script);
+  }, []);
 
   return (
     <div className={styles.profileContainer}>

--- a/src/components/PostProfile/PostProfile.jsx
+++ b/src/components/PostProfile/PostProfile.jsx
@@ -5,6 +5,7 @@ import kakaoImage from "../../assets/images/shareicon/Kakao.svg";
 import linkShareImage from "../../assets/images/shareicon/Link.svg";
 import { shareKakao } from "../../utils/shareKakao";
 import { useEffect } from "react";
+import { shareFacebook } from "../../utils/shareFacebook";
 
 const POST_BASE_URL = "https://openmind-api.vercel.app/5-4/post";
 
@@ -28,8 +29,12 @@ export default function PostProfile({ userProfile }) {
       imgSource: linkShareImage,
       onClick: handleCopyLinkClipBoard,
     },
-    { altMessage: "link to facebook", imgSource: faceBookImage },
     { altMessage: "link to kakao", imgSource: kakaoImage, onClick: shareKakao },
+    {
+      altMessage: "link to facebook",
+      imgSource: faceBookImage,
+      onClick: shareFacebook,
+    },
   ];
 
   useEffect(() => {

--- a/src/components/PostProfile/PostProfile.jsx
+++ b/src/components/PostProfile/PostProfile.jsx
@@ -12,7 +12,11 @@ const Icons = [
 export default function PostProfile({ userProfile }) {
   return (
     <div className={styles.profileContainer}>
-      <img className={styles.profileImage} src={userProfile.imageSource} />
+      <img
+        className={styles.profileImage}
+        src={userProfile.imageSource}
+        alt={userProfile.name}
+      />
       <span className={styles.profileUserName}>{userProfile.name}</span>
       <ul className={styles.shareButtonBox}>
         {Icons.map((item, index) => (
@@ -26,18 +30,3 @@ export default function PostProfile({ userProfile }) {
     </div>
   );
 }
-
-/* const linkShareIcon = {
-  altMessage: "copy link",
-  imgSource: linkShareImage,
-};
-
-const faceBookIcon = {
-  altMessage: "link to facebook",
-  imgSource: faceBookImage,
-};
-
-const kakaoIcon = {
-  altMessage: "link to kakao",
-  imgSource: kakaoImage,
-}; */

--- a/src/components/PostProfile/PostProfile.jsx
+++ b/src/components/PostProfile/PostProfile.jsx
@@ -4,7 +4,7 @@ import faceBookImage from "../../assets/images/shareicon/Facebook.svg";
 import kakaoImage from "../../assets/images/shareicon/Kakao.svg";
 import linkShareImage from "../../assets/images/shareicon/Link.svg";
 import { shareKakao } from "../../utils/shareKakao";
-import { useEffect } from "react";
+
 import { shareFacebook } from "../../utils/shareFacebook";
 
 const POST_BASE_URL = "https://openmind-api.vercel.app/5-4/post";
@@ -36,14 +36,6 @@ export default function PostProfile({ userProfile }) {
       onClick: shareFacebook,
     },
   ];
-
-  useEffect(() => {
-    const script = document.createElement("script");
-    script.src = "https://developers.kakao.com/sdk/js/kakao.js";
-    script.async = true;
-    document.body.appendChild(script);
-    return () => document.body.removeChild(script);
-  }, []);
 
   return (
     <div className={styles.profileContainer}>

--- a/src/components/PostProfile/PostProfile.jsx
+++ b/src/components/PostProfile/PostProfile.jsx
@@ -1,15 +1,35 @@
+import React, { useState } from "react";
 import styles from "./PostProfile.module.css";
 import faceBookImage from "../../assets/images/shareicon/Facebook.svg";
 import kakaoImage from "../../assets/images/shareicon/Kakao.svg";
 import linkShareImage from "../../assets/images/shareicon/Link.svg";
 
-const Icons = [
-  { altMessage: "copy link", imgSource: linkShareImage },
-  { altMessage: "link to facebook", imgSource: faceBookImage },
-  { altMessage: "link to kakao", imgSource: kakaoImage },
-];
+const POST_BASE_URL = "https://openmind-api.vercel.app/5-4/post";
 
 export default function PostProfile({ userProfile }) {
+  const [showToast, setShowToast] = useState(false);
+
+  const handleCopyLinkClipBoard = async () => {
+    const copiedLink = `${POST_BASE_URL}/${userProfile.id}`;
+    try {
+      await navigator.clipboard.writeText(copiedLink);
+      setShowToast(true); // 토스트 메시지 표시
+      setTimeout(() => setShowToast(false), 3000); // 5초 후에 토스트 메시지 숨김
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  const SHARE_BUTTON_INFO = [
+    {
+      altMessage: "copy link",
+      imgSource: linkShareImage,
+      onClick: handleCopyLinkClipBoard,
+    },
+    { altMessage: "link to facebook", imgSource: faceBookImage },
+    { altMessage: "link to kakao", imgSource: kakaoImage },
+  ];
+
   return (
     <div className={styles.profileContainer}>
       <img
@@ -19,14 +39,17 @@ export default function PostProfile({ userProfile }) {
       />
       <span className={styles.profileUserName}>{userProfile.name}</span>
       <ul className={styles.shareButtonBox}>
-        {Icons.map((item, index) => (
+        {SHARE_BUTTON_INFO.map((item, index) => (
           <li key={index}>
-            <button className={styles.shareButton}>
+            <button className={styles.shareButton} onClick={item.onClick}>
               <img alt={item.altMessage} src={item.imgSource} />
             </button>
           </li>
         ))}
       </ul>
+      <div className={`${styles.toast} ${showToast ? styles.show : ""}`}>
+        URL이 복사되었습니다
+      </div>
     </div>
   );
 }

--- a/src/components/PostProfile/PostProfile.module.css
+++ b/src/components/PostProfile/PostProfile.module.css
@@ -47,7 +47,7 @@
   font-size: 14px;
   font-weight: 500;
   line-height: 18px;
-  position: absolute;
+  position: fixed;
   bottom: 60px;
   opacity: 0; /* 초기에는 투명하게 설정 */
   transition: opacity 0.5s ease-in-out; /* 서서히 나타나고 사라지도록 설정 */

--- a/src/components/PostProfile/PostProfile.module.css
+++ b/src/components/PostProfile/PostProfile.module.css
@@ -35,3 +35,24 @@
     cursor: pointer;
   }
 }
+
+.toast {
+  background: var(--grayscaleColor600);
+  color: var(--grayscaleColor100);
+  border-radius: 8px;
+  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+  padding: 12px 20px;
+  justify-content: center;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 18px;
+  position: absolute;
+  bottom: 60px;
+  opacity: 0; /* 초기에는 투명하게 설정 */
+  transition: opacity 0.5s ease-in-out; /* 서서히 나타나고 사라지도록 설정 */
+}
+
+.toast.show {
+  opacity: 1; /* 토스트 메시지가 표시될 때 투명도를 조정하여 나타남 */
+}

--- a/src/components/PostProfile/PostProfile.module.css
+++ b/src/components/PostProfile/PostProfile.module.css
@@ -31,4 +31,7 @@
 
 .shareButton {
   width: 40px;
+  &:hover {
+    cursor: pointer;
+  }
 }

--- a/src/utils/shareFacebook.js
+++ b/src/utils/shareFacebook.js
@@ -1,0 +1,3 @@
+export const shareFacebook = () => {
+  window.open("http://www.facebook.com/sharer.php?u=www.naver.com");
+};

--- a/src/utils/shareKakao.js
+++ b/src/utils/shareKakao.js
@@ -1,0 +1,31 @@
+export const shareKakao = () => {
+  if (window.Kakao) {
+    const kakao = window.Kakao;
+    if (!kakao.isInitialized()) {
+      kakao.init("2bc24641675f91dae9be60e52cab838e"); // 카카오에서 제공받은 javascript key를 넣어줌 -> .env파일에서 호출시킴
+    }
+
+    kakao.Share.sendDefault({
+      objectType: "feed", // 카카오 링크 공유 여러 type들 중 feed라는 타입 -> 자세한 건 카카오에서 확인
+      content: {
+        title: "test", // 인자값으로 받은 title
+        description: "설명", // 인자값으로 받은 title
+        imageUrl:
+          "https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8",
+        link: {
+          mobileWebUrl: "https://developers.kakao.com/", // 인자값으로 받은 route(uri 형태)
+          webUrl: "https://developers.kakao.com/",
+        },
+      },
+      buttons: [
+        {
+          title: "title",
+          link: {
+            mobileWebUrl: "https://developers.kakao.com/",
+            webUrl: "https://developers.kakao.com/",
+          },
+        },
+      ],
+    });
+  }
+};


### PR DESCRIPTION
## 주요 구현
- 복사버튼 클릭시 임시로 설정된 링크 복사및 토스트 메세지 생성
- 카카오톡 버튼 클릭시 카카오톡 공유하기로 임시 링크 공유
- 페이스북 버튼 클릭시 임시 링크 공유
임시 링크는 추후 저희 배포링크로 수정 가능할 것 같습니다.

## 스크린샷
<img width="1920" alt="chrome_QLywwnYWf0" src="https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/77979028/ef893234-6a5e-445a-af27-6b12ba1a021a">
<img width="1920" alt="mwoqJqrlVq" src="https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/77979028/7d876937-4b87-4e6c-a373-eb4434a610f4">

![eOjeZpglEA](https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/77979028/863d1fa4-f02c-4f91-8d22-c1391dbdcf11)
