### PR TITLE
[고학영] List Page 스타일링 수정

### DIFF
--- a/src/components/ListSortModal/ListSortModal.jsx
+++ b/src/components/ListSortModal/ListSortModal.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import styles from "./ListSortModal.module.css";
 import arrowUp from "../../assets/images/icon/Arrow-up.svg";
 import arrowDown from "../../assets/images/icon/Arrow-down.svg";
@@ -6,6 +6,23 @@ import arrowDown from "../../assets/images/icon/Arrow-down.svg";
 function ListSortModal({ onClickSort, currentSortValue }) {
   const [viewDropdown, setViewDropdown] = useState(false); // 드롭다운 토글 useState
   const [arrowDirection, setArrowDirection] = useState(arrowDown); // 토글메뉴 화살표 useState
+  const wrapperRef = useRef(null);
+
+  /** handleClickOutside 마우스다운 이벤트 추가 이벤트 발생 후 이벤트제거로 데이터 누수 방지*/
+  useEffect(() => {
+    document.addEventListener("click", handleClickOutside);
+    return () => {
+      document.removeEventListener("click", handleClickOutside);
+    };
+  }, [wrapperRef.current]);
+
+  /** 드롭다운 메뉴 이외의 영역을 클릭시 드롭다운 메뉴 닫힘 */
+  const handleClickOutside = (e) => {
+    if (wrapperRef && !wrapperRef.current.contains(e.target)) {
+      setViewDropdown(false);
+      setArrowDirection(arrowDown);
+    }
+  };
 
   const dropdownToggle = () => {
     setViewDropdown(!viewDropdown);
@@ -14,7 +31,11 @@ function ListSortModal({ onClickSort, currentSortValue }) {
 
   return (
     <div className={styles.sortMenu}>
-      <button className={styles.selectSortButton} onClick={dropdownToggle}>
+      <button
+        className={styles.selectSortButton}
+        onClick={dropdownToggle}
+        ref={wrapperRef}
+      >
         {currentSortValue === "time" ? "최신순" : "이름순"}
         <img src={arrowDirection} alt={arrowDirection} />
       </button>

--- a/src/components/ListSortModal/ListSortModal.module.css
+++ b/src/components/ListSortModal/ListSortModal.module.css
@@ -39,6 +39,7 @@
   border: 1px solid var(--grayscaleColor300);
   background: var(--grayscaleColor100);
   box-shadow: 0px 4px 4px 0px rgba(140, 140, 140, 0.25);
+  z-index: 1;
 }
 
 .alignButton {

--- a/src/components/QuestionCard/QuestionCard.jsx
+++ b/src/components/QuestionCard/QuestionCard.jsx
@@ -5,15 +5,21 @@ import { Link } from "react-router-dom";
 function QuestionCard({ feed }) {
   const { name, imageSource, questionCount, id } = feed;
 
+  let userName = "";
+
+  if (name.length > 10) {
+    userName = name.slice(0, 10) + "...";
+  } else userName = name;
+
   return (
-    <Link href={`/post/${id}`} className={styles.cardWrapper}>
+    <Link to={`/post/${id}`} className={styles.cardWrapper}>
       <div className={styles.profileSection}>
         <img
           className={styles.profileImage}
           src={imageSource}
           alt="프로필 사진"
         />
-        <h2 className={styles.profileName}>{name}</h2>
+        <h2 className={styles.profileName}>{userName}</h2>
       </div>
       <div className={styles.infoSection}>
         <div className={styles.infoItem}>

--- a/src/components/QuestionCard/QuestionCard.jsx
+++ b/src/components/QuestionCard/QuestionCard.jsx
@@ -7,8 +7,8 @@ function QuestionCard({ feed }) {
 
   let userName = "";
 
-  if (name.length > 10) {
-    userName = name.slice(0, 10) + "...";
+  if (name.length > 8) {
+    userName = name.slice(0, 8) + "...";
   } else userName = name;
 
   return (

--- a/src/components/QuestionCard/QuestionCard.jsx
+++ b/src/components/QuestionCard/QuestionCard.jsx
@@ -20,6 +20,9 @@ function QuestionCard({ feed }) {
           alt="프로필 사진"
         />
         <h2 className={styles.profileName}>{userName}</h2>
+        {userName.length > 8 && (
+          <span className={styles.fullUserName__hover}>{name}</span>
+        )}
       </div>
       <div className={styles.infoSection}>
         <div className={styles.infoItem}>

--- a/src/components/QuestionCard/QuestionCard.module.css
+++ b/src/components/QuestionCard/QuestionCard.module.css
@@ -1,4 +1,5 @@
 .cardWrapper {
+  position: relative;
   max-width: 180px;
   background-color: var(--grayscaleColor100);
   display: block;
@@ -28,6 +29,25 @@
   font-size: 20px;
   font-weight: 400;
   line-height: 1.25;
+}
+
+.fullUserName__hover {
+  display: none;
+}
+
+.profileName:hover + .fullUserName__hover {
+  position: absolute;
+  display: inline-block;
+  top: 56px;
+  left: 84px;
+  background-color: var(--brownColor100);
+  width: fit-content;
+  height: auto;
+  padding: 8px;
+  border-radius: 8px;
+  line-height: 16px;
+  font-size: 12px;
+  z-index: 1;
 }
 
 .infoSection {

--- a/src/components/QuestionCardList/QuestionCardList.jsx
+++ b/src/components/QuestionCardList/QuestionCardList.jsx
@@ -3,13 +3,15 @@ import styles from "./QuestionCardList.module.css";
 
 function QuestionCardList({ sortedFeeds }) {
   return (
-    <ul className={styles.listContainer}>
-      {sortedFeeds?.map((feed, id) => (
-        <li key={id}>
-          <QuestionCard feed={feed} />
-        </li>
-      ))}
-    </ul>
+    <div className={styles.questionCard_wrapper}>
+      <ul className={styles.listContainer}>
+        {sortedFeeds?.map((feed, id) => (
+          <li key={id}>
+            <QuestionCard feed={feed} />
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }
 

--- a/src/components/QuestionCardList/QuestionCardList.module.css
+++ b/src/components/QuestionCardList/QuestionCardList.module.css
@@ -2,20 +2,20 @@
   width: 100%;
   max-width: 940px;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-template-columns: repeat(4, minmax(186px, 222px));
   gap: 20px;
   margin: 30px 0 40px;
 }
 
 @media (max-width: 870px) {
   .listContainer {
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: repeat(3, 222px);
   }
 }
 
 @media (max-width: 767px) {
   .listContainer {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(2, minmax(122px, 222px));
     gap: 16px;
   }
 }

--- a/src/pages/QuestionCardListPage/QuestionCardListPage.jsx
+++ b/src/pages/QuestionCardListPage/QuestionCardListPage.jsx
@@ -20,21 +20,21 @@ function QuestionCardListPage() {
   const [prevPage, setPrevPage] = useState(null);
   const [totalPage, setTotalPage] = useState();
   const [searchParams, setSearchParams] = useSearchParams();
-  
+
   /*const [limit, setLimit] = useState(() => (window.innerWidth <= 870 ? 6 : 8)); // 브라우저 너비를 감지하여 870px이하에서 6개
   const [width, setWidth] = useState(window.innerWidth); // 브라우저 너비 감지 useState
   const [currentOffset, setCurrentOffset] = useState(0); */
   /**윈도우 객체를 받아서 width에 저장하는 함수 */
-//   const handleResize = () => {
-//     setWidth(window.innerWidth);
-//     if (window.innerWidth <= 870) {
-//       setLimit(6);
-//     } else setLimit(8);
-//   };
+  //   const handleResize = () => {
+  //     setWidth(window.innerWidth);
+  //     if (window.innerWidth <= 870) {
+  //       setLimit(6);
+  //     } else setLimit(8);
+  //   };
 
-//   useEffect(() => {
-//     window.addEventListener("resize", handleResize);
-//   }, [width]);
+  //   useEffect(() => {
+  //     window.addEventListener("resize", handleResize);
+  //   }, [width]);
 
   const getQueryParams = (url) => {
     const urlObj = new URL(url);
@@ -55,7 +55,7 @@ function QuestionCardListPage() {
   const handlePageChange = useCallback(
     async (url) => {
       if (!url) return;
-      
+
       try {
         const { limit, offset } = getQueryParams(url);
         const newFeeds = await getSubjects({
@@ -84,7 +84,6 @@ function QuestionCardListPage() {
     },
     [searchParams, setSearchParams]
   ); // 쿼리파라미터를 설정해주는 함수
-
 
   const displaySubjects = useCallback(async () => {
     const limit = searchParams.get("limit") || INITIALQUERY.limit;

--- a/src/pages/QuestionCardListPage/QuestionCardListPage.module.css
+++ b/src/pages/QuestionCardListPage/QuestionCardListPage.module.css
@@ -107,11 +107,23 @@
   }
 }
 
+@media (max-width: 870px) {
+  .pageContainer {
+    padding: 5vh 32px 10vh;
+  }
+  .titleBox {
+    display: flex;
+    justify-content: space-between;
+    margin: 47px 0 0;
+  }
+}
+
 /* 모바일 사이즈 */
 @media (max-width: 767px) {
   .pageContainer {
-    padding: 0 24px;
+    padding: 40px 24px;
     align-items: center;
+    height: auto;
   }
 
   .titleAndSortBox {


### PR DESCRIPTION
- [X] 드롭다운 메뉴 외부클릭시 닫히게 수정했습니다.
- [X] 질문카드 이름이 8자 초과할 시 ..으로 요약하고 호버했을 경우 전체이름이 나오도록 하였습니다.
- [X] 태블릿 이하 환경에서의 스타일을 수정했습니다.


<img width="484" alt="스크린샷 2024-04-15 오후 6 37 13" src="https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/159985297/12206d8a-951b-4e88-832e-0fa93ca8ff8b">

질문카드 이름 요약

<img width="245" alt="스크린샷 2024-04-15 오후 6 38 11" src="https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/159985297/ca99c7d0-cd4e-479c-adea-becb87550d8a">

요약된 질문카드 이름 호버시 전체네임 출력( 요약되지 않은 이름에는 출력X)

<img width="852" alt="스크린샷 2024-04-15 오후 3 55 43" src="https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/159985297/7c2ef5b4-88e3-44f1-bfda-54934516f7de">
수정된 태블릿환경 레이아웃</br>

<img width="369" alt="스크린샷 2024-04-15 오후 3 56 00" src="https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/159985297/0fac4e72-2f8f-42f6-89d3-1ce4948c08db"></br>
수정된 모바일환경 레이아웃