### PR TITLE
[배의진] 거절하기 기능 보완 / 디자인 수정

### DIFF
--- a/src/components/QuestionFeedCard/QuestionFeedCard.jsx
+++ b/src/components/QuestionFeedCard/QuestionFeedCard.jsx
@@ -56,9 +56,11 @@ export default function QuestionFeedCard({
       console.error("질문 목록을 가져오는 중에 오류가 발생했습니다:");
     }
   };
+
   // 드롭다운 답변 거절하기 기능
   const handleToggleRejectClick = async (question) => {
     let isRejected = true;
+    setIsEditing(false);
     const contentOfRejectedAnswer = "&1a3nd8g";
     // 답변이 있을 때 거절하기, 거절풀기
     if (

--- a/src/components/QuestionFeedCard/QuestionFeedCard.jsx
+++ b/src/components/QuestionFeedCard/QuestionFeedCard.jsx
@@ -48,36 +48,42 @@ export default function QuestionFeedCard({
     await updateQuestions();
   };
 
-
   const handleReactionSubmit = async (newReaction) => {
     try {
       let result = await postReaction(newReaction, question.id);
       setCurrentQuestion(result);
     } catch (error) {
-        console.error("질문 목록을 가져오는 중에 오류가 발생했습니다:");
+      console.error("질문 목록을 가져오는 중에 오류가 발생했습니다:");
     }
-  }
-  // 드롭다운에서 거절하기 버튼 클릭 시 질문답변에 거절하기 출력
+  };
+  // 드롭다운 답변 거절하기 기능
   const handleToggleRejectClick = async (question) => {
-    let isRejected = true; // 기본값 설정
-
-    if (question.answer) {
+    let isRejected = true;
+    const contentOfRejectedAnswer = "&1a3nd8g";
+    // 답변이 있을 때 거절하기, 거절풀기
+    if (
+      question.answer &&
+      question.answer.content !== contentOfRejectedAnswer
+    ) {
       isRejected = !question.answer.isRejected;
       await rejectAnswer(question.answer.id, isRejected);
-    } else {
-      await createAnswer(question.id, "거절된 답변", isRejected);
+      // 답변이 없을 때 거절하기
+    } else if (question.answer === null) {
+      await createAnswer(question.id, contentOfRejectedAnswer, isRejected);
+      // 답변이 없을 때 거절풀기
+    } else if (question.answer.content === contentOfRejectedAnswer) {
+      console.log(question.answer?.content === contentOfRejectedAnswer);
+      await deleteSingleAnswer(question);
     }
 
     await updateQuestions();
     setShowDropdown(!showDropdown);
   };
 
-
   // 개별 질문, 해당 질문에 달린 답변들 삭제
   const handleDeleteQuestionClick = () => {
     modalHandler("정말 질문을 삭제하시겠습니까?", handleDeleteQuestion);
   };
-
 
   const handleDeleteQuestion = async (confirmed) => {
     if (confirmed) {
@@ -86,7 +92,6 @@ export default function QuestionFeedCard({
       await updateQuestions();
     }
   };
-
 
   const likeIconSrc = currentQuestion.like === 0 ? likeIconDefault : likeIcon;
   const likeTextSrc =

--- a/src/components/QuestionFeedCard/QuestionFeedCard.jsx
+++ b/src/components/QuestionFeedCard/QuestionFeedCard.jsx
@@ -93,6 +93,7 @@ export default function QuestionFeedCard({
     }
   };
 
+  // '좋아요''싫어요'가 0일때, 0이상일 때 각기 다른 스타일 적용
   const likeIconSrc = currentQuestion.like === 0 ? likeIconDefault : likeIcon;
   const likeTextSrc =
     currentQuestion.like === 0 ? styles.reactionTextDefault : styles.likeText;
@@ -181,29 +182,29 @@ export default function QuestionFeedCard({
       )}
 
       <div className={styles.judgeAnswerContainer}>
-        <div className={styles.judgeAnswerWrapper}>
+        <div>
           <button
             onClick={() => handleReactionSubmit("like")}
             type="submit"
             className={styles.judge}
           >
             <img src={likeIconSrc} alt="좋아요버튼" />
+            <span
+              className={likeTextSrc}
+            >{`좋아요 ${currentQuestion.like}`}</span>
           </button>
-          <span
-            className={likeTextSrc}
-          >{`좋아요 ${currentQuestion.like}`}</span>
         </div>
-        <div className={styles.judgeAnswerWrapper}>
+        <div>
           <button
             onClick={() => handleReactionSubmit("dislike")}
             type="submit"
             className={styles.judge}
           >
             <img src={dislikeIconSrc} alt="싫아요버튼" />
+            <span
+              className={dislikeTextSrc}
+            >{`싫어요 ${currentQuestion.dislike}`}</span>
           </button>
-          <span
-            className={dislikeTextSrc}
-          >{`싫어요 ${currentQuestion.dislike}`}</span>
         </div>
       </div>
     </div>

--- a/src/components/QuestionFeedCard/QuestionFeedCard.module.css
+++ b/src/components/QuestionFeedCard/QuestionFeedCard.module.css
@@ -91,32 +91,33 @@
 .judgeAnswerContainer {
   display: flex;
   width: 100%;
-  gap: 32px;
+  /* gap: 32px; */
+  gap: 16px;
   padding-top: 24px;
   border-top: 1px solid var(--grayscaleColor300);
-}
-
-.judgeAnswerWrapper {
-  display: flex;
-  gap: 6px;
 }
 
 .judge {
   align-items: center;
   display: flex;
   gap: 6px;
-  font-size: 14px;
+  border: 1px solid var(--grayscaleColor300);
+  border-radius: 9999px;
+  padding: 10px;
 }
 
 .reactionTextDefault {
+  font-size: 14px;
   color: var(--grayscaleColor400);
 }
 
 .likeText {
+  font-size: 14px;
   color: var(--blueColor);
 }
 
 .dislikeText {
+  font-size: 14px;
   color: var(--grayscaleColor600);
 }
 

--- a/src/components/QuestionFeedList/QuestionFeedList.module.css
+++ b/src/components/QuestionFeedList/QuestionFeedList.module.css
@@ -26,10 +26,15 @@
 }
 
 .questionEmptyImage {
-  margin: 111px 277px 65px;
+  width: 150px;
+  height: 154px;
+  margin: 70px 277px 65px;
 
   @media (max-width: 767px) {
-    margin: 106px;
+    height: 118px;
+    width: 114px;
+    margin: 90px;
+    margin-top: 66px;
   }
 }
 
@@ -44,4 +49,8 @@
   font-size: 20px;
   font-style: normal;
   line-height: 25px;
+
+  @media (max-width: 767px) {
+    font-size: 18px;
+  }
 }

--- a/src/components/QuestionModal/QuestionModal.jsx
+++ b/src/components/QuestionModal/QuestionModal.jsx
@@ -1,7 +1,6 @@
 import speechBubble from "../../assets/images/Messages.svg";
 import styles from "./QuestionModal.module.css";
 import TextAreaForm from "../TextAreaForm/TextAreaForm";
-import postQuestion from "../../utils/postpageAPI/postQuestion";
 
 export default function QuestionModal({
   closeModal,

--- a/src/pages/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage.jsx
@@ -27,10 +27,12 @@ export default function PostPage() {
   const handleSendQuestion = async (textValue) => {
     const formData = { content: textValue };
     const subjectId = id;
-    const response = await postQuestion(formData, subjectId);
+    await postQuestion(formData, subjectId);
     handleModalClose();
     updateUserQuestions();
-    console.log(userQuestions);
+    window.scrollTo({
+      top: 0,
+    });
   };
 
   useEffect(() => {


### PR DESCRIPTION
### answer page
- 거절하기 수정 1 : 답변 없을 때 거절하고, 다시 풀면 답변을 삭제하도록 수정 (기존에는 '거절된 답변'이란 답변이 나타났음)
- 거절하기 수정 2 : 기존에 답변이 달려 있는 상태에서 답변을 수정할 때에도 거절하기가 가능하도록 함.
- 좋아요, 싫어요 버튼 클릭 영역 확대

### question modal page
- 질문 작성 완료 시 post page 상단으로 화면 이동

### post page
- 질문이 없는 post page 에서, 모바일 화면에서 양 옆 여백 없는 부분 수정 (박스 사이즈 조정 )

![image](https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/160081323/2028cc32-fd7e-4af7-90bd-8e1f972962df)

![image](https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/160081323/01d298bf-6931-49f5-88e6-79d22024659f)

![image](https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/160081323/9d105c5f-5454-47f7-a3d6-8b7533d0a2d4)

 