### PR TITLE
[배의진] 답변하기 페이지에서 프로필 사진 위치 수정

### DIFF
--- a/src/components/QuestionFeedCard/QuestionFeedCard.module.css
+++ b/src/components/QuestionFeedCard/QuestionFeedCard.module.css
@@ -51,7 +51,10 @@
   display: flex;
   gap: 12px;
   width: 100%;
-  flex-wrap: wrap;
+
+  @media (max-width: 767px) {
+    flex-direction: column;
+  }
 }
 
 .userProfileImage {


### PR DESCRIPTION
### answer page
답변하기 페이지에서 프로필 사진 위치를 모바일일 때 위로 가도록 수정

pc 버전, tablet 버전
![image](https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/160081323/b7446f99-c9f4-47d4-90fd-daaae6caf65d)

모바일 버전
![image](https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/160081323/557695f1-2914-439c-b9bd-5ebd98ea1e26)
