### PR TITLE
feat: 공유하기 관련 url 설정

### DIFF
--- a/src/components/PostProfile/PostProfile.jsx
+++ b/src/components/PostProfile/PostProfile.jsx
@@ -29,7 +29,12 @@ export default function PostProfile({ userProfile }) {
       imgSource: linkShareImage,
       onClick: handleCopyLinkClipBoard,
     },
-    { altMessage: "link to kakao", imgSource: kakaoImage, onClick: shareKakao },
+    {
+      altMessage: "link to kakao",
+      imgSource: kakaoImage,
+      onClick: () =>
+        shareKakao(`https://openmind5-4.netlify.app/post/${userProfile.id}`),
+    },
     {
       altMessage: "link to facebook",
       imgSource: faceBookImage,

--- a/src/components/PostProfile/PostProfile.jsx
+++ b/src/components/PostProfile/PostProfile.jsx
@@ -7,13 +7,13 @@ import { shareKakao } from "../../utils/shareKakao";
 
 import { shareFacebook } from "../../utils/shareFacebook";
 
-const POST_BASE_URL = "https://openmind-api.vercel.app/5-4";
-
 export default function PostProfile({ userProfile }) {
   const [showToast, setShowToast] = useState(false);
 
+  const SHARE_URL = `https://openmind5-4.netlify.app/post/${userProfile.id}`;
+
   const handleCopyLinkClipBoard = async () => {
-    const copiedLink = `${POST_BASE_URL}/${userProfile.id}`;
+    const copiedLink = SHARE_URL;
     try {
       await navigator.clipboard.writeText(copiedLink);
       setShowToast(true); // 토스트 메시지 표시
@@ -32,13 +32,12 @@ export default function PostProfile({ userProfile }) {
     {
       altMessage: "link to kakao",
       imgSource: kakaoImage,
-      onClick: () =>
-        shareKakao(`https://openmind5-4.netlify.app/post/${userProfile.id}`),
+      onClick: () => shareKakao(SHARE_URL),
     },
     {
       altMessage: "link to facebook",
       imgSource: faceBookImage,
-      onClick: shareFacebook,
+      onClick: () => shareFacebook(SHARE_URL),
     },
   ];
 

--- a/src/utils/shareFacebook.js
+++ b/src/utils/shareFacebook.js
@@ -1,3 +1,3 @@
-export const shareFacebook = () => {
-  window.open("http://www.facebook.com/sharer.php?u=www.naver.com");
+export const shareFacebook = (route) => {
+  window.open(`http://www.facebook.com/sharer.php?u=${route}`);
 };

--- a/src/utils/shareKakao.js
+++ b/src/utils/shareKakao.js
@@ -1,4 +1,4 @@
-export const shareKakao = () => {
+export const shareKakao = (route) => {
   if (window.Kakao) {
     const kakao = window.Kakao;
     if (!kakao.isInitialized()) {
@@ -8,24 +8,25 @@ export const shareKakao = () => {
     kakao.Share.sendDefault({
       objectType: "feed", // 카카오 링크 공유 여러 type들 중 feed라는 타입 -> 자세한 건 카카오에서 확인
       content: {
-        title: "test", // 인자값으로 받은 title
-        description: "설명", // 인자값으로 받은 title
-        imageUrl:
-          "https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8",
+        title: "Openmind", // 인자값으로 받은 title
+        description: "무엇이든 물어보세요", // 인자값으로 받은 title
+        imageUrl: "https://ifh.cc/g/k2Wdn3.png",
         link: {
-          mobileWebUrl: "https://developers.kakao.com/", // 인자값으로 받은 route(uri 형태)
-          webUrl: "https://developers.kakao.com/",
+          mobileWebUrl: route, // 인자값으로 받은 route(uri 형태)
+          webUrl: route,
         },
       },
       buttons: [
         {
-          title: "title",
+          title: "웹으로 보기",
           link: {
-            mobileWebUrl: "https://developers.kakao.com/",
-            webUrl: "https://developers.kakao.com/",
+            mobileWebUrl: route,
+            webUrl: route,
           },
         },
       ],
+
+      installTalk: true,
     });
   }
 };


### PR DESCRIPTION
링크 복사시 openmind5-4.netlify.app의 /post/id로 복사가 됩니다
카카오톡 공유와 페이스북 공유도 위와 같은 주소로 설정이 됩니다

![image](https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/77979028/712887b6-d2f3-4dfc-9d57-534aa9303f55)
![image](https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/77979028/16536502-ed2a-4c32-92cb-397fb7038eaa)
