### PR TITLE
[배의진] 질문하기, 답변하기 페이지 아래 배경색 적용 안되고 하얗게 되는 문제 해결

### DIFF
--- a/src/pages/PostPage/PostPage.module.css
+++ b/src/pages/PostPage/PostPage.module.css
@@ -6,7 +6,7 @@
   gap: 12px;
   position: relative;
   width: 100%;
-  height: 100vh;
+  height: 100%;
   background: var(--grayscaleColor200);
 }
 


### PR DESCRIPTION
height 100vh 일 때, 질문 갯수가 많아져 페이지 길이가 길어질 경우, 100vh 를 초과하는 부분에 대해서 회색 배경색이 적용되지 않는 문제를 height 100% 로 수정해서 해결했습니다.
