### PR TITLE
Feat: 데이터 요청에 실패할 시 사용자에게 제공할 페이지 추가

### DIFF
--- a/src/pages/QuestionCardListPage/QuestionCardListPage.jsx
+++ b/src/pages/QuestionCardListPage/QuestionCardListPage.jsx
@@ -1,12 +1,11 @@
 import QuestionCardList from "../../components/QuestionCardList/QuestionCardList";
 import ListHeader from "../../components/ListHeader/ListHeader";
 import Pagination from "../../components/Pagination/Pagination";
+import ListSortModal from "../../components/ListSortModal/ListSortModal";
 import styles from "./QuestionCardListPage.module.css";
 import { useEffect, useState } from "react";
 import { getSubjects } from "../../utils/listPageApi/getSubjects";
 import { useSearchParams } from "react-router-dom";
-import ListSortModal from "../../components/ListSortModal/ListSortModal";
-import NotFoundPage from "../NotFoundPage/NotFoundPage";
 import { getOffsetByStringUrl } from "./getOffsetByStringUrl";
 
 export const INITIALQUERY = {
@@ -28,6 +27,7 @@ function QuestionCardListPage() {
     const { limit, offset, sort, page } = params;
 
     setIsLoading(true);
+    setIsError(false);
 
     try {
       const feedDatas = await getSubjects({ limit, offset, sort });
@@ -105,19 +105,29 @@ function QuestionCardListPage() {
 
   return (
     <>
-      {isError ? (
-        <NotFoundPage />
-      ) : (
-        <div className={styles.pageContainer}>
-          <section className={styles.contentContainer}>
-            <ListHeader />
-            <div className={styles.titleAndSortBox}>
-              <h1 className={styles.title}>누구에게 질문할까요?</h1>
-              <ListSortModal handleSort={handleSortChange} />
+      <div className={styles.pageContainer}>
+        <section className={styles.contentContainer}>
+          <ListHeader />
+          <div className={styles.titleAndSortBox}>
+            <h1 className={styles.title}>누구에게 질문할까요?</h1>
+            <ListSortModal handleSort={handleSortChange} />
+          </div>
+          {isError ? (
+            <div className={styles.errorBox}>
+              <h2 className={styles.errorMessage}>
+                데이터를 불러오는데 실패했습니다.
+              </h2>
+              <button
+                onClick={() => displaySubjects(INITIALQUERY)}
+                className={styles.errorButton}
+              >
+                다시 시도
+              </button>
             </div>
+          ) : (
             <div className={styles.listAndPaginationBox}>
               {isLoading ? (
-                <div className={styles.LoadingBox}></div>
+                <div className={styles.loadingBox}></div>
               ) : (
                 <QuestionCardList
                   currentPage={currentPage}
@@ -132,9 +142,9 @@ function QuestionCardListPage() {
                 onPage={handlePageChangeByPage}
               />
             </div>
-          </section>
-        </div>
-      )}
+          )}
+        </section>
+      </div>
     </>
   );
 }

--- a/src/pages/QuestionCardListPage/QuestionCardListPage.module.css
+++ b/src/pages/QuestionCardListPage/QuestionCardListPage.module.css
@@ -97,14 +97,44 @@
   align-items: center;
 }
 
-.LoadingBox {
+.loadingBox {
   width: 100%;
-  height: 414px;
+  max-width: 940px;
+  height: 394px;
   display: flex;
   justify-content: center;
   align-items: center;
   font-size: 24px;
   font-weight: 500;
+  margin-bottom: 20px;
+}
+
+.errorBox {
+  width: 100%;
+  height: 454px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.errorMessage {
+  font-size: 24px;
+  margin-bottom: 20px;
+}
+
+.errorButton {
+  background-color: var(--brownColor400);
+  color: var(--grayscaleColor100);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.375;
+  border-radius: 8px;
+  padding: 11px 24px;
+}
+
+.errorButton:hover {
+  background-color: var(--brownColor500);
 }
 
 /* 태블릿 사이즈 */


### PR DESCRIPTION
데이터 요청에 실패할 시 사용자에게 제공할 페이지를 추가했습니다.
다시 요청 버튼을 누르면 이니셜쿼리의 내용으로 재요청하게끔 설정했습니다.

### 에러 박스
<img width="1383" alt="스크린샷 2024-04-22 오후 6 12 22" src="https://github.com/Codeit-FE-5-part2-4/OpenMind/assets/113277713/ef7d638f-4c0e-4897-89d9-dc149d6ff69c">
